### PR TITLE
Fix description for 'Violets Don't Wilt' letter

### DIFF
--- a/assets/locales/en/m01-the-atlantic-wall.json
+++ b/assets/locales/en/m01-the-atlantic-wall.json
@@ -14,7 +14,7 @@
     },
     "4": {
       "label": "Violets Don't Wilt",
-      "desc": "Inside the hotel safe on the first floor. The safe can be opened with the @link[code.5] or a satchel charge."
+      "desc": "Inside the hotel safe on the second floor. The safe can be opened with the @link[code.5] or a satchel charge."
     },
     "5": {
       "label": "Pests in the Garden",


### PR DESCRIPTION
The location text was incorrect it is on the second floor. You have to go up the stairs

Other locales will also have to be changed if this pull request is accepted